### PR TITLE
Fix/dead members

### DIFF
--- a/backlog
+++ b/backlog
@@ -1,5 +1,3 @@
-- Configuration rework (done)
-
 - Documentation
     - Document internals
     - Readme (partly done)
@@ -8,17 +6,13 @@
 
 - API cleanup
     - Remove recording feature (?)
-    - Remove SendAll (done)
     - Remove features only required for experiments (?)
 
 - Code overhaul
-    - View seperation (done partly)
-    - Accusations from dead members and on dead members
-    - Rebuttal rework
+    - Rebuttal fix (valid accuser)
     - Detach visualizer component from rest of system
     - Cleanup errors
-    - ShouldRebuttal rework
-    - NewNode rework (pass certificates, interace for visualizer?)
+    - NewNode rework (pass certificates, inteface for visualizer?)
     - Client/server interface rework (export?)
     - Rpc package testing
     - Udp package testing
@@ -29,13 +23,12 @@
     - Change ID's in protobuf to strings?
     - Ping limit per monitor interval (how many each interval)
     - Avoid transferring all accusations
-    - Support dead accusers
     - Rpc client/server overhaul (grpc streams? stream interceptor for neighbour/validation?)
+    - Rework old tests according to the new test setup
 
 - Testing overhaul
     - Re-write all tests after code overhaul
     - Full behavior tests
-    - Change test setup
 
 - Persistence (Client)
     - Certificates (peers and CA)
@@ -43,6 +36,14 @@
 
 - Certificates
     - Change address placements
+
+
+- Done
+    - Change test setup
+    - Complete view rework/seperation
+    - Accusations from dead members and on dead members
+    - Remove SendAll
+    - Configuration rework
 
 
 Do seperate pull requests for all (for tracking)

--- a/core/discovery/view.go
+++ b/core/discovery/view.go
@@ -398,7 +398,7 @@ func (v *View) FindNeighbours(id string) []*Peer {
 	return v.rings.findNeighbours(id)
 }
 
-func (v *View) ValidAccuser(accused, accuser string, ringNum uint32) bool {
+func (v *View) ValidAccuser(accused, accuser *Peer, ringNum uint32) bool {
 	v.liveMutex.RLock()
 	defer v.liveMutex.RUnlock()
 

--- a/core/discovery/view_test.go
+++ b/core/discovery/view_test.go
@@ -616,11 +616,12 @@ func (suite *ViewTestSuite) TestValidAccuser() {
 
 	view.AddLive(p)
 
-	assert.False(suite.T(), view.ValidAccuser(p.Id, view.self.Id, view.rings.numRings+1), "Should return false with invalid ring number.")
-	assert.False(suite.T(), view.ValidAccuser("", view.self.Id, view.rings.numRings), "Should return false with no accused.")
-	assert.False(suite.T(), view.ValidAccuser(p.Id, "", view.rings.numRings), "Should return false with no accuser.")
+	assert.False(suite.T(), view.ValidAccuser(p, view.self, view.rings.numRings+1),
+		"Should return false with invalid ring number.")
 
-	assert.True(suite.T(), view.ValidAccuser(p.Id, view.self.Id, view.rings.numRings), "Should return true with valid parameters.")
+	assert.True(suite.T(), view.ValidAccuser(p, view.self, view.rings.numRings),
+		"Should return true with valid parameters.")
+
 }
 
 func (suite *ViewTestSuite) TestIsAlive() {

--- a/core/handlers_test.go
+++ b/core/handlers_test.go
@@ -399,28 +399,6 @@ func (suite *HandlerTestSuite) TestEvalAccusation() {
 		},
 
 		{
-			acc: discovery.NewAccusation(1, "Non-existing Id", selfId,
-				1, node.privKey),
-			accuser:   node.self,
-			accused:   nil,
-			out:       errNoAccused,
-			timer:     false,
-			rebuttal:  false,
-			isAccused: false,
-		},
-
-		{
-			acc: discovery.NewAccusation(1, prev.Id, "Non-existing Id",
-				1, node.privKey),
-			accuser:   nil,
-			accused:   prev,
-			out:       errNoAccuser,
-			timer:     false,
-			rebuttal:  false,
-			isAccused: false,
-		},
-
-		{
 			acc: discovery.NewAccusation(1, succ.Id, prev.Id, 1,
 				suite.privMap[prev.Id]),
 			accuser:   prev,
@@ -469,16 +447,6 @@ func (suite *HandlerTestSuite) TestEvalAccusation() {
 			timer:     true,
 			rebuttal:  false,
 			isAccused: true,
-		},
-
-		{
-			acc:       discovery.NewAccusation(1, randomPeer.Id, selfId, 1, node.privKey),
-			accuser:   node.self,
-			accused:   randomPeer,
-			out:       errNoAccused,
-			timer:     false,
-			rebuttal:  false,
-			isAccused: false,
 		},
 	}
 


### PR DESCRIPTION
### Fix
Accusations from dead members are now valid and fully equal to an accusation from a live member.
Accusations on dead members are now replaced if new ones are received with closer predecessors.

Changes to reflect the new behavior and tests added. 
