### PR TITLE
Fix/rebuttal

### DIFF
--- a/bootstrap/launcher.go
+++ b/bootstrap/launcher.go
@@ -37,7 +37,7 @@ type Launcher struct {
 
 type application interface {
 	Start()
-	ShutDown()
+	Close()
 	Addr() string
 }
 
@@ -100,7 +100,7 @@ func (l *Launcher) shutDownApplications() {
 	defer l.applicationListMutex.RUnlock()
 
 	for _, n := range l.applicationList {
-		n.ShutDown()
+		n.Close()
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -167,6 +167,7 @@ func readConfig() error {
 	viper.SetDefault("monitor_interval", 10)
 	viper.SetDefault("view_update_interval", 10)
 	viper.SetDefault("ping_limit", 3)
+	viper.SetDefault("pings_per_interval", 3)
 	viper.SetDefault("removal_timeout", 60)
 	viper.SetDefault("max_concurrent_messages", 5)
 

--- a/core/discovery/view.go
+++ b/core/discovery/view.go
@@ -353,8 +353,6 @@ func (v *View) ShouldRebuttal(epoch uint64, ringNum uint32) bool {
 	v.self.noteMutex.Lock()
 	defer v.self.noteMutex.Unlock()
 
-	// TODO check if accuser is my direct predecessor
-
 	if eq := v.self.note.Equal(epoch); eq {
 		newMask := v.self.note.mask
 

--- a/core/handlers.go
+++ b/core/handlers.go
@@ -191,13 +191,20 @@ func (n *Node) mergeAccusations(accusations []*gossip.Accusation) {
 	}
 
 	for _, acc := range accusations {
-		accuser := n.view.Peer(string(acc.GetAccuser()))
-		if accuser == nil {
+		accId := string(acc.GetAccused())
+		accuserId := string(acc.GetAccuser())
+
+		accuser := n.view.Peer(accuserId)
+		if accuserId == n.self.Id {
+			accuser = n.self
+		} else if accuser == nil {
 			continue
 		}
 
-		accused := n.view.Peer(string(acc.GetAccused()))
-		if accused == nil || accused.Note() == nil {
+		accused := n.view.Peer(accId)
+		if accId == n.self.Id {
+			accused = n.self
+		} else if accused == nil || accused.Note() == nil {
 			continue
 		}
 

--- a/core/handlers_test.go
+++ b/core/handlers_test.go
@@ -377,6 +377,26 @@ func (suite *HandlerTestSuite) TestEvalAccusation() {
 		isAccused bool
 	}{
 		{
+			acc:       discovery.NewAccusation(1, selfId, succ.Id, 1, suite.privMap[succ.Id]),
+			accuser:   succ,
+			accused:   node.self,
+			out:       errInvalidAccuser,
+			timer:     false,
+			rebuttal:  false,
+			isAccused: false,
+		},
+
+		{
+			acc:       discovery.NewUnsignedAccusation(1, selfId, prev.Id, 1),
+			accuser:   prev,
+			accused:   node.self,
+			out:       errInvalidSignature,
+			timer:     false,
+			rebuttal:  false,
+			isAccused: false,
+		},
+
+		{
 			acc:       discovery.NewAccusation(2, selfId, prev.Id, 1, suite.privMap[prev.Id]),
 			accuser:   prev,
 			accused:   node.self,


### PR DESCRIPTION
### Fix
- Rebuttals are now initiated only when the accusation was valid.
- Fixed bug where accusation on self were not evaluated.
- Fixed bug where failed pings variable was incremented even when ping succeeded.
- Now longer evaluates own certificate in gossip interactions.

### Features
- Added support for simulating byzantine behaviour (periodically pausing pong responses), used by visualizer.
- Added pings_per_interval configuration variable, controls how many ring successors are pinged at each ping interval (defaults to 3).
