### PR TITLE
Unable to handle critical extention

### DIFF
--- a/cauth/cauth.go
+++ b/cauth/cauth.go
@@ -66,7 +66,6 @@ type group struct {
 
 // LoadCa initializes a CA from a file path
 func LoadCa(path string) (*Ca, error) {
-
 	keyPath := filepath.Join(path, "key.pem")
 
 	fp, err := ioutil.ReadFile(keyPath)
@@ -133,16 +132,16 @@ func LoadCa(path string) (*Ca, error) {
 // Create and returns  a new certificate authority instance.
 // Generates a private/public keypair for internal use.
 func NewCa(path string) (*Ca, error) {
-
 	privKey, err := genKeys()
 	if err != nil {
 		return nil, err
 	}
 
 	c := &Ca{
-		privKey: privKey,
-		pubKey:  privKey.Public(),
-		path:    path,
+		privKey:     privKey,
+		pubKey:      privKey.Public(),
+		path:        path,
+		keyFilePath: "key.pem",
 	}
 
 	return c, nil
@@ -174,7 +173,6 @@ func (c *Ca) SavePrivateKey() error {
 
 // SaveCertificate Public key / certificate to the given io object.
 func (c *Ca) SaveCertificate() error {
-
 	for _, j := range c.groups {
 
 		p := filepath.Join(c.path, fmt.Sprintf("g-%s.pem", j.groupCert.SerialNumber))
@@ -209,7 +207,6 @@ func (c *Ca) Shutdown() {
 // Starts serving certificate signing requests, requires the amount of gossip rings
 // to be used in the network between ifrit clients.
 func (c *Ca) Start(host string, port int) error {
-
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return err

--- a/cauth/cauth.go
+++ b/cauth/cauth.go
@@ -237,7 +237,7 @@ func (c *Ca) NewGroup(ringNum, bootNodes uint32) error {
 
 	ext := pkix.Extension{
 		Id:       RingNumberOid,
-		Critical: true,
+		Critical: false,
 		Value:    ringBytes,
 	}
 

--- a/cauth/cauth_test.go
+++ b/cauth/cauth_test.go
@@ -38,7 +38,7 @@ func TestTLSconnection(t *testing.T) {
 		SerialNumber:          serialNumber,
 		SubjectKeyId:          []byte{1, 2, 3, 4, 5},
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 		Subject: pkix.Name{
 			Country:            []string{"SHIEEET"},
 			Organization:       []string{"Yjwt"},

--- a/cmd/ca/main.go
+++ b/cmd/ca/main.go
@@ -17,16 +17,14 @@ var DefaultPermission = os.FileMode(0750)
 
 // Config contains all configurable parameters for the Ifrit CA daemon.
 var Config = struct {
-	Name            string `default:"Ifrit Certificate Authority"`
-	Version         string `default:"1.0.0"`
-	Host            string `default:"127.0.0.1"`
-	Port            int    `default:"8321"`
-	Path            string `default:"./ifrit-cad"`
-	KeyPath         string `default:"key.pem"`
-	CertificatePath string `default:"cert.pem"`
-	NumRings        uint32 `default:"3"`
-	NumBootNodes    uint32 `default:"0"`
-	LogFile         string `default:""`
+	Name         string `default:"Ifrit Certificate Authority"`
+	Version      string `default:"1.0.0"`
+	Host         string `default:"127.0.0.1"`
+	Port         int    `default:"8321"`
+	Path         string `default:"./ifrit-cad"`
+	NumRings     uint32 `default:"3"`
+	NumBootNodes uint32 `default:"0"`
+	LogFile      string `default:""`
 }{}
 
 // saveState saves ca private key and public certificates to disk.
@@ -61,10 +59,10 @@ func main() {
 	configor.New(&configor.Config{Debug: false, ENVPrefix: "IFRIT"}).Load(&Config, configFile, "/etc/ifrit/config.yaml")
 
 	args.StringVar(&Config.LogFile, "logfile", "", "Log to file.")
-	args.StringVar(&Config.Host, "host", Config.Host, "Hostname")
-	args.IntVar(&Config.Port, "port", Config.Port, "Port")
-	args.StringVar(&Config.Path, "path", Config.Path, "Path to runtime files")
-	args.BoolVar(&createNew, "new", false, "Initialize new ca structure")
+	args.StringVar(&Config.Host, "host", Config.Host, "Hostname.")
+	args.IntVar(&Config.Port, "port", Config.Port, "Port number.")
+	args.StringVar(&Config.Path, "path", Config.Path, "Path to runtime files.")
+	args.BoolVar(&createNew, "new", false, "Initialize new CA structure.")
 	args.Parse(os.Args[1:])
 
 	// Setup logging
@@ -78,55 +76,45 @@ func main() {
 	r.SetHandler(h)
 
 	// Attempt to load existing group
-
 	var ca *cauth.Ca
 	var err error
 
 	if !createNew {
 		ca, err = cauth.LoadCa(Config.Path)
 		if err != nil {
-			println("Error loading CA. Run with --new option if CA does not exit.")
+			fmt.Fprintln(os.Stderr, "Error loading CA. Run with --new option if CA does not exit.")
 			os.Exit(1)
 		}
 	} else {
-
 		println("Creating CA")
 
 		// Create run directory
 		err := os.MkdirAll(Config.Path, DefaultPermission)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
 		ca, err = cauth.NewCa(Config.Path)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
 		// Add initial group.
 		err = ca.NewGroup(Config.NumRings, Config.NumBootNodes)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	}
-
-	// Create new group
-	// err = ca.NewGroup(Config.NumRings, Config.NumBootNodes)
-	// if err != nil {
-	//	fmt.Println(err)
-	//	os.Exit(1)
-	// }
 
 	// Save state
 	saveState(ca)
 	defer saveState(ca)
 
 	// Start the daemon
-
-	fmt.Printf("Starting Ifrit CAd on port %d\n", Config.Port)
+	fmt.Printf("Starting Ifrit CA daemon on port %d\n", Config.Port)
 	go ca.Start(Config.Host, Config.Port)
 
 	// Handle SIGTERM


### PR DESCRIPTION
The Ifrit clients are unable to perform authentication handshake due to unhandled critical extension error. Each time an application message is sent, the ```gRPC``` library panics. To fix this, I set the OID number assoicated with the rings to be non-critical. In ```func (c *Ca) NewGroup(ringNum, bootNodes uint32) error```, it looks like this:

```
 ext := pkix.Extension{
    RingNumberOid,
    Critical: false,
    ringBytes,
 }
```
It is unclear how or if, we should set it to critical. Take a look at ```Extensions``` and ```ExtraExtensions``` at https://golang.org/pkg/crypto/x509/#Certificate. 