### PR TITLE
Client & CA Feature Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now you'll want to import the library:
 ```
 Now you can create and start a client
 ```go
-c, err := ifrit.NewClient()
+c, err := ifrit.NewClient(udpPort, tcpPort)
 if err != nil {
     panic(err)
 }

--- a/cauth/cauth.go
+++ b/cauth/cauth.go
@@ -365,11 +365,13 @@ func (c *Ca) certificateSigning(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ipAddr, err := net.ResolveIPAddr("ip4", strings.Split(reqCert.Subject.Locality[0], ":")[0])
-	// if err != nil {
-	// 	log.Error(err.Error())
-	// 	return
-	// }
+	/*
+		ipAddr, err := net.ResolveIPAddr("ip4", strings.Split(reqCert.Subject.Locality[0], ":")[0])
+		if err != nil {
+			log.Error(err.Error())
+			return
+		}
+	*/
 	id := g.genId()
 
 	newCert := &x509.Certificate{

--- a/cauth/cauth.go
+++ b/cauth/cauth.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"io/ioutil"
 	"math/big"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -366,11 +365,11 @@ func (c *Ca) certificateSigning(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ipAddr, err := net.ResolveIPAddr("ip4", strings.Split(reqCert.Subject.Locality[0], ":")[0])
-	if err != nil {
-		log.Error(err.Error())
-		return
-	}
+	// ipAddr, err := net.ResolveIPAddr("ip4", strings.Split(reqCert.Subject.Locality[0], ":")[0])
+	// if err != nil {
+	// 	log.Error(err.Error())
+	// 	return
+	// }
 	id := g.genId()
 
 	newCert := &x509.Certificate{
@@ -381,10 +380,10 @@ func (c *Ca) certificateSigning(w http.ResponseWriter, r *http.Request) {
 		NotAfter:        time.Now().AddDate(10, 0, 0),
 		ExtraExtensions: []pkix.Extension{ext},
 		PublicKey:       reqCert.PublicKey,
-		IPAddresses:     []net.IP{ipAddr.IP},
-		DNSNames:        reqCert.DNSNames,
-		ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:        x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		// IPAddresses:     []net.IP{ipAddr.IP},
+		DNSNames:    reqCert.DNSNames,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 	}
 
 	signedCert, err := x509.CreateCertificate(rand.Reader, newCert, g.groupCert, reqCert.PublicKey, c.privKey)

--- a/cauth/cauth.go
+++ b/cauth/cauth.go
@@ -2,11 +2,11 @@ package cauth
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
-	"context"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/binary"
@@ -36,7 +36,7 @@ var (
 	errNoKeyFilepath    = errors.New("Tried to save private key with no filepath set in config.")
 	errInvalidBootNodes = errors.New("Number of boot nodes needs to be greater than zero.")
 	errInvalidNumRings  = errors.New("Number of rings needs to be greater than zero.")
-	errPortNotSet 		= errors.New("Port number is not set")
+	errPortNotSet       = errors.New("Port number is not set")
 
 	RingNumberOid asn1.ObjectIdentifier = []int{2, 5, 13, 37}
 )
@@ -50,7 +50,7 @@ type Ca struct {
 
 	groups []*group
 
-	addr string
+	addr       string
 	httpServer *http.Server
 }
 
@@ -212,7 +212,7 @@ func (c *Ca) SaveCertificate() error {
 // Shutsdown the certificate authority instance, will no longer serve signing requests.
 func (c *Ca) Shutdown() {
 	log.Info("Shuting down Lohpi certificate authority")
-	
+
 	idleConnsClosed := make(chan struct{})
 	go func() {
 		// We received an interrupt signal, shut down.
@@ -317,10 +317,10 @@ func (c *Ca) httpHandler(addr string) error {
 	}
 
 	c.httpServer = &http.Server{
-		Addr: 	 		":" + port,
-		Handler: 		r,
-		ReadTimeout: 	time.Second * 10,
-		WriteTimeout: 	time.Second * 10,
+		Addr:         ":" + port,
+		Handler:      r,
+		ReadTimeout:  time.Second * 10,
+		WriteTimeout: time.Second * 10,
 	}
 
 	return c.httpServer.ListenAndServe()
@@ -382,6 +382,7 @@ func (c *Ca) certificateSigning(w http.ResponseWriter, r *http.Request) {
 		ExtraExtensions: []pkix.Extension{ext},
 		PublicKey:       reqCert.PublicKey,
 		IPAddresses:     []net.IP{ipAddr.IP},
+		DNSNames:        reqCert.DNSNames,
 		ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:        x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 	}

--- a/client.go
+++ b/client.go
@@ -224,12 +224,12 @@ func (c *Client) SetGossipContent(data []byte) error {
 	return nil
 }
 
-func (c *Client) SavePrivateKey() error {
-	return c.node.SavePrivateKey()
+func (c *Client) SavePrivateKey(path string) error {
+	return c.node.SavePrivateKey(path)
 }
 
-func (c *Client) SaveCertificate() error {
-	return c.node.SaveCertificate()
+func (c *Client) SaveCertificate(path string) error {
+	return c.node.SaveCertificate(path)
 }
 
 func readConfig() error {

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ type Client struct {
 
 type ClientConfig struct {
 	UdpPort, TcpPort int
-	// cu *comm.CryptoUnit
+	CertPath         string
 }
 
 /*
@@ -227,29 +227,12 @@ func (c *Client) SetGossipContent(data []byte) error {
 	return nil
 }
 
-func (c *Client) SavePrivateKey() error {
-	// if c.keyFilePath == "" {
-	// 	return errNoKeyFilepath
-	// }
+func (c *Client) SavePrivateKey(p string) error {
+	return c.node.SavePrivateKey(p)
+}
 
-	// p := filepath.Join(c.path, c.keyFilePath)
-
-	// f, err := os.Create(p)
-	// if err != nil {
-	// 	log.Error(err.Error())
-	// 	return err
-	// }
-
-	// b := x509.MarshalPKCS1PrivateKey(c.privKey)
-
-	// block := &pem.Block{
-	// 	Type:  "RSA PRIVATE KEY",
-	// 	Bytes: b,
-	// }
-
-	// return pem.Encode(f, block)
-
-	return nil
+func (c *Client) SaveCertificate(p string) error {
+	return c.node.SaveCertificates(p)
 }
 
 func readConfig() error {

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ type Client struct {
 	node *core.Node
 }
 
-type NodeConfig struct {
+type ClientConfig struct {
 	UdpPort, TcpPort int
 	// cu *comm.CryptoUnit
 }
@@ -41,20 +41,20 @@ var (
  *
  * Change: Added argument struct containing specifiable context for ifrit-client.
  */
-func NewClient(nConf *NodeConfig) (*Client, error) {
+func NewClient(cliCfg *ClientConfig) (*Client, error) {
 	err := readConfig()
 	if err != nil {
 		return nil, err
 	}
 
 	// This is where nodes' udp-port is set. - marius
-	udpConn, udpAddr, err := netutil.ListenUdp(nConf.UdpPort)
+	udpConn, udpAddr, err := netutil.ListenUdp(cliCfg.UdpPort)
 	if err != nil {
 		return nil, err
 	}
 
 	// This is where nodes' tcp-port is set. - marius
-	l, err := netutil.GetListener(nConf.TcpPort)
+	l, err := netutil.GetListener(cliCfg.TcpPort)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -18,6 +18,7 @@ type Client struct {
 
 type ClientConfig struct {
 	UdpPort, TcpPort int
+	Hostname         string
 	CertPath         string
 }
 

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package ifrit
 import (
 	"crypto/x509/pkix"
 	"errors"
+	"fmt"
 
 	log "github.com/inconshreveable/log15"
 
@@ -56,13 +57,14 @@ func NewClient(cliCfg *ClientConfig) (*Client, error) {
 	log.Debug("addrs", "rpc", l.Addr().String(), "udp", udpAddr)
 
 	pk := pkix.Name{
-		Locality: []string{l.Addr().String(), udpAddr},
+		/* Tell crypto-unit where this client can be reached. */
+		Locality: []string{fmt.Sprintf("%s:%d", cliCfg.Hostname, cliCfg.TcpPort), udpAddr},
 	}
 
 	caAddr := viper.GetString("ca_addr")
 
 	if cliCfg.CertPath == "" {
-		cu, err = comm.NewCu(pk, caAddr)
+		cu, err = comm.NewCu(pk, caAddr, cliCfg.Hostname)
 		if err != nil {
 			return nil, err
 		}

--- a/client.go
+++ b/client.go
@@ -35,6 +35,7 @@ type GossipHandler interface {
 var (
 	errNoData      = errors.New("Supplied data is of length 0")
 	errNoCaAddress = errors.New("Config does not contain address of CA")
+	errNoClientArg = errors.New("Client argument zero")
 )
 
 /* Creates and returns a new ifrit client instance.
@@ -42,6 +43,10 @@ var (
  * Change: Added argument struct containing specifiable context for ifrit-client.
  */
 func NewClient(cliCfg *ClientConfig) (*Client, error) {
+	if cliCfg == nil {
+		return nil, errNoClientArg
+	}
+
 	err := readConfig()
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -55,14 +55,12 @@ func NewClient(cliCfg *ClientConfig) (*Client, error) {
 		return nil, err
 	}
 
-	// This is where nodes' udp-port is set. - marius
-	udpConn, udpAddr, err := netutil.ListenUdp(cliCfg.UdpPort)
+	udpConn, udpAddr, err := netutil.ListenUdp(cliCfg.Hostname, cliCfg.UdpPort)
 	if err != nil {
 		return nil, err
 	}
 
-	// This is where nodes' tcp-port is set. - marius
-	l, err := netutil.GetListener(cliCfg.TcpPort)
+	l, err := netutil.GetListener(cliCfg.Hostname, cliCfg.TcpPort)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +85,6 @@ func NewClient(cliCfg *ClientConfig) (*Client, error) {
 		}
 	}
 
-	// Pre-existing certificates goes in here? - marius
 	c, err := comm.NewComm(cu.Certificate(), cu.CaCertificate(), cu.Priv(), l)
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -238,7 +238,7 @@ func (c *Client) SavePrivateKey(path string) error {
 }
 
 func (c *Client) SaveCertificate(path string) error {
-	return c.node.SaveCertificates(path)
+	return c.node.SaveCertificate(path)
 }
 
 func readConfig() error {

--- a/client.go
+++ b/client.go
@@ -40,7 +40,7 @@ var (
 
 /* Creates and returns a new ifrit client instance.
  *
- * Change: Added argument struct containing specifiable context for ifrit-client.
+ * Change: Added argument struct containing specifiable context for ifrit-client. - marius
  */
 func NewClient(cliCfg *ClientConfig) (*Client, error) {
 	if cliCfg == nil {
@@ -223,6 +223,31 @@ func (c *Client) SetGossipContent(data []byte) error {
 	}
 
 	c.node.SetExternalGossipContent(data)
+
+	return nil
+}
+
+func (c *Client) SavePrivateKey() error {
+	// if c.keyFilePath == "" {
+	// 	return errNoKeyFilepath
+	// }
+
+	// p := filepath.Join(c.path, c.keyFilePath)
+
+	// f, err := os.Create(p)
+	// if err != nil {
+	// 	log.Error(err.Error())
+	// 	return err
+	// }
+
+	// b := x509.MarshalPKCS1PrivateKey(c.privKey)
+
+	// block := &pem.Block{
+	// 	Type:  "RSA PRIVATE KEY",
+	// 	Bytes: b,
+	// }
+
+	// return pem.Encode(f, block)
 
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -70,7 +70,13 @@ func NewClient(cliCfg *ClientConfig) (*Client, error) {
 		Locality: []string{l.Addr().String(), udpAddr},
 	}
 
-	cu, err := comm.NewCu(pk, viper.GetString("ca_addr"))
+	/* Change: Pass empty string to NewCu() if no pre-existing certificate-path given. */
+	caAddr := cliCfg.CertPath
+	if caAddr == "" {
+		caAddr = viper.GetString("ca_addr")
+	}
+
+	cu, err := comm.NewCu(pk, caAddr, cliCfg.CertPath)
 	if err != nil {
 		return nil, err
 	}
@@ -227,12 +233,12 @@ func (c *Client) SetGossipContent(data []byte) error {
 	return nil
 }
 
-func (c *Client) SavePrivateKey(p string) error {
-	return c.node.SavePrivateKey(p)
+func (c *Client) SavePrivateKey(path string) error {
+	return c.node.SavePrivateKey(path)
 }
 
-func (c *Client) SaveCertificate(p string) error {
-	return c.node.SaveCertificates(p)
+func (c *Client) SaveCertificate(path string) error {
+	return c.node.SaveCertificates(path)
 }
 
 func readConfig() error {

--- a/client.go
+++ b/client.go
@@ -17,21 +17,9 @@ type Client struct {
 }
 
 type ClientConfig struct {
-	UdpPort, TcpPort int
-	Hostname         string
-	CertPath         string
+	UdpPort, TcpPort   int
+	Hostname, CertPath string
 }
-
-/*
-type MessageHandler interface {
-	Incoming([]byte) ([]byte, error)
-}
-
-type GossipHandler interface {
-	Incoming([]byte) ([]byte, error)
-	Response([]byte)
-}
-*/
 
 var (
 	errNoData      = errors.New("Supplied data is of length 0")

--- a/client.go
+++ b/client.go
@@ -57,7 +57,6 @@ func NewClient(cliCfg *ClientConfig) (*Client, error) {
 	log.Debug("addrs", "rpc", l.Addr().String(), "udp", udpAddr)
 
 	pk := pkix.Name{
-		/* Tell crypto-unit where this client can be reached. */
 		Locality: []string{fmt.Sprintf("%s:%d", cliCfg.Hostname, cliCfg.TcpPort), udpAddr},
 	}
 
@@ -111,10 +110,7 @@ func NewClientCertificate(cliCfg *ClientConfig, path string) error {
 
 	caAddr := viper.GetString("ca_addr")
 
-	/* Getting cauth to sign a certificate with another FQDN
-	 * that does not yet exist on azure is NO HABLA BUENO.
-	 */
-	cu, err := comm.NewCu(pk, caAddr, cliCfg.Hostname)
+	cu, err := comm.NewStaticCu(pk, caAddr, cliCfg.Hostname)
 	if err != nil {
 		return err
 	}

--- a/cmd/ca/ca_config.yaml
+++ b/cmd/ca/ca_config.yaml
@@ -1,5 +1,0 @@
-boot_nodes: 32
-certificate_filepath: /var/tmp/ca_certificate
-key_filepath: /var/tmp/ca_key
-num_rings: 20
-port: 8300

--- a/cmd/ca/ca_config.yaml
+++ b/cmd/ca/ca_config.yaml
@@ -1,0 +1,5 @@
+boot_nodes: 32
+certificate_filepath: /var/tmp/ca_certificate
+key_filepath: /var/tmp/ca_key
+num_rings: 20
+port: 8300

--- a/cmd/ca/main.go
+++ b/cmd/ca/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/jinzhu/configor"
 	"os"
 	"os/signal"
 	"runtime"
-	"syscall"
 	"strconv"
+	"syscall"
+
+	"github.com/jinzhu/configor"
 
 	log "github.com/inconshreveable/log15"
 	"github.com/joonnna/ifrit/cauth"
@@ -45,10 +46,9 @@ func saveState(ca *cauth.Ca) {
 }
 
 func main() {
-
 	var h log.Handler
 	var configFile string
-	var createNew bool	
+	var createNew bool
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
@@ -87,7 +87,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		println("Creating CA")
+		fmt.Println("Config:", Config)
 
 		// Create run directory
 		err := os.MkdirAll(Config.Path, DefaultPermission)

--- a/comm/crypto_unit.go
+++ b/comm/crypto_unit.go
@@ -75,15 +75,15 @@ func NewCu(identity pkix.Name, caAddr string, dnsLabel string) (*CryptoUnit, err
 		return nil, errNoIp
 	}
 
-	serviceIP, err := net.LookupIP(serviceAddr[0])
-	if err != nil {
-		return nil, err
-	}
+	// serviceIP, err := net.LookupIP(serviceAddr[0])
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	ip := net.ParseIP(serviceIP[0].String())
-	if ip == nil {
-		return nil, errNoIp
-	}
+	// ip := net.ParseIP(serviceIP[0].String())
+	// if ip == nil {
+	// 	return nil, errNoIp
+	// }
 
 	priv, err := genKeys()
 	if err != nil {
@@ -263,7 +263,7 @@ func (cu *CryptoUnit) SavePrivateKey(path string) error {
 		return err
 	}
 
-	log.Debug("private-key stored", "path", path)
+	log.Info("private-key stored", "path", path)
 
 	return f.Close()
 }
@@ -291,7 +291,7 @@ func (cu *CryptoUnit) SaveCertificate(path string) error {
 			log.Error(err.Error())
 		}
 
-		log.Debug(fmt.Sprintf("known-certificate #%v stored", i+1), "path", fname)
+		log.Info(fmt.Sprintf("known-certificate #%v stored", i+1), "path", fname)
 	}
 
 	/*
@@ -304,7 +304,7 @@ func (cu *CryptoUnit) SaveCertificate(path string) error {
 		log.Error(err.Error())
 	}
 
-	log.Debug("CA-certificate stored", "path", fname)
+	log.Info("CA-certificate stored", "path", fname)
 
 	/*
 	 * Self.
@@ -316,7 +316,7 @@ func (cu *CryptoUnit) SaveCertificate(path string) error {
 		log.Error(err.Error())
 	}
 
-	log.Debug("own-certificate stored", "path", fname)
+	log.Info("own-certificate stored", "path", fname)
 
 	return nil
 }
@@ -366,7 +366,7 @@ func loadCertSet(certPath string) (*certSet, error) {
 		return nil, err
 	}
 
-	log.Debug("own-certificate loaded", "path", matches[0])
+	log.Info("own-certificate loaded", "path", matches[0])
 
 	/*
 	 * Neighbour certificates.
@@ -388,7 +388,7 @@ func loadCertSet(certPath string) (*certSet, error) {
 
 		knownCerts = append(knownCerts, gCert)
 
-		log.Debug(fmt.Sprintf("known certificate #%d loaded", i+1), "path", path)
+		log.Info(fmt.Sprintf("known certificate #%d loaded", i+1), "path", path)
 	}
 
 	/*
@@ -406,7 +406,7 @@ func loadCertSet(certPath string) (*certSet, error) {
 		return nil, err
 	}
 
-	log.Debug("ca-certificate loaded", "path", matches[0])
+	log.Info("ca-certificate loaded", "path", matches[0])
 
 	return &certSet{
 		ownCert:    selfCert,
@@ -457,7 +457,7 @@ func loadPrivKey(certPath string) (*ecdsa.PrivateKey, error) {
 		return nil, err
 	}
 
-	log.Debug("private-key loaded", "path", path)
+	log.Info("private-key loaded", "path", path)
 
 	return privKey, nil
 }
@@ -572,7 +572,6 @@ func genId() []byte {
 	nonce := make([]byte, 32)
 	rand.Read(nonce)
 	return nonce
-
 }
 
 func genSerialNumber() (*big.Int, error) {

--- a/comm/crypto_unit.go
+++ b/comm/crypto_unit.go
@@ -34,7 +34,6 @@ var (
 	errInvlPath    = errors.New("Argument path to load empty")
 	errPemDecode   = errors.New("Unable to decode content in given file")
 	errInvlKeyPath = errors.New("Storage path-argument is invalid")
-	errNoCertMatch = errors.New("Storage path gave no hits on certificates")
 )
 
 type CryptoUnit struct {
@@ -230,8 +229,8 @@ func (cu *CryptoUnit) Sign(data []byte) ([]byte, []byte, error) {
 /* Save private key for node crypto-unit to new file in argument directory-path.
  * - marius
  */
-func (cu *CryptoUnit) SavePrivateKey() error {
-	path := fmt.Sprintf("certificate-%s", cu.self.SerialNumber)
+func (cu *CryptoUnit) SavePrivateKey(path string) error {
+	path = filepath.Join(path, fmt.Sprintf("certificate-%s", cu.self.SerialNumber))
 
 	err := os.MkdirAll(path, fs.ModePerm)
 	if err != nil {
@@ -268,8 +267,9 @@ func (cu *CryptoUnit) SavePrivateKey() error {
 /* Save network-neighbours, ca, and own certificate in new files inside argument path.
  * - marius
  */
-func (cu *CryptoUnit) SaveCertificate() error {
-	path := fmt.Sprintf("certificate-%s", cu.self.SerialNumber)
+func (cu *CryptoUnit) SaveCertificate(path string) error {
+
+	path = filepath.Join(path, fmt.Sprintf("certificate-%s", cu.self.SerialNumber))
 
 	err := os.MkdirAll(path, fs.ModePerm)
 	if err != nil {
@@ -287,7 +287,7 @@ func (cu *CryptoUnit) SaveCertificate() error {
 			log.Error(err.Error())
 		}
 
-		log.Debug(fmt.Sprintf("known-certificate #%v stored", i), "path", fname)
+		log.Debug(fmt.Sprintf("known-certificate #%v stored", i+1), "path", fname)
 	}
 
 	/*
@@ -352,7 +352,7 @@ func loadCertSet(certPath string) (*certSet, error) {
 	if err != nil {
 		return nil, err
 	} else if matches == nil {
-		return nil, errNoCertMatch
+		return nil, errors.New(fmt.Sprintf("Storage path '%s' gave no hits on certificates", certPath))
 	} else if len(matches) > 1 {
 		return nil, errors.New(fmt.Sprintf("Argument path: \"%s\" contains more than one private-key", certPath))
 	}
@@ -369,7 +369,7 @@ func loadCertSet(certPath string) (*certSet, error) {
 	if err != nil {
 		return nil, err
 	} else if matches == nil {
-		return nil, errNoCertMatch
+		return nil, errors.New(fmt.Sprintf("Storage path '%s' gave no hits on certificates", certPath))
 	}
 
 	knownCerts := make([]*x509.Certificate, 0, len(matches))

--- a/comm/crypto_unit.go
+++ b/comm/crypto_unit.go
@@ -233,6 +233,7 @@ func (cu *CryptoUnit) Sign(data []byte) ([]byte, []byte, error) {
  * - marius
  */
 func (cu *CryptoUnit) SavePrivateKey(path string) error {
+
 	path = filepath.Join(path, fmt.Sprintf("certificate-%s", cu.self.SerialNumber))
 
 	err := os.MkdirAll(path, fs.ModePerm)
@@ -365,6 +366,8 @@ func loadCertSet(certPath string) (*certSet, error) {
 		return nil, err
 	}
 
+	log.Debug("own-certificate loaded", "path", matches[0])
+
 	/*
 	 * Neighbour certificates.
 	 */
@@ -377,13 +380,15 @@ func loadCertSet(certPath string) (*certSet, error) {
 
 	knownCerts := make([]*x509.Certificate, 0, len(matches))
 
-	for _, path := range matches {
+	for i, path := range matches {
 		gCert, err := loadCert(path)
 		if err != nil {
 			return nil, err
 		}
 
 		knownCerts = append(knownCerts, gCert)
+
+		log.Debug(fmt.Sprintf("known certificate #%d loaded", i+1), "path", path)
 	}
 
 	/*
@@ -400,6 +405,8 @@ func loadCertSet(certPath string) (*certSet, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	log.Debug("ca-certificate loaded", "path", matches[0])
 
 	return &certSet{
 		ownCert:    selfCert,
@@ -449,6 +456,8 @@ func loadPrivKey(certPath string) (*ecdsa.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	log.Debug("private-key loaded", "path", path)
 
 	return privKey, nil
 }

--- a/comm/crypto_unit.go
+++ b/comm/crypto_unit.go
@@ -34,6 +34,7 @@ var (
 	errInvlPath    = errors.New("Argument path to load empty")
 	errPemDecode   = errors.New("Unable to decode content in given file")
 	errInvlKeyPath = errors.New("Storage path-argument is invalid")
+	errNoCertMatch = errors.New("Storage path gave no hits on certificates")
 )
 
 type CryptoUnit struct {
@@ -350,6 +351,8 @@ func loadCertSet(certPath string) (*certSet, error) {
 	matches, err := filepath.Glob(filepath.Join(certPath, "self-*.pem"))
 	if err != nil {
 		return nil, err
+	} else if matches == nil {
+		return nil, errNoCertMatch
 	} else if len(matches) > 1 {
 		return nil, errors.New(fmt.Sprintf("Argument path: \"%s\" contains more than one private-key", certPath))
 	}
@@ -365,6 +368,8 @@ func loadCertSet(certPath string) (*certSet, error) {
 	matches, err = filepath.Glob(filepath.Join(certPath, "g-*.pem"))
 	if err != nil {
 		return nil, err
+	} else if matches == nil {
+		return nil, errNoCertMatch
 	}
 
 	knownCerts := make([]*x509.Certificate, 0, len(matches))

--- a/core/node.go
+++ b/core/node.go
@@ -94,8 +94,8 @@ type certManager interface {
 	ContactList() []*x509.Certificate
 	NumRings() uint32
 	Trusted() bool
-	SavePrivateKey() error
-	SaveCertificate() error
+	SavePrivateKey(string) error
+	SaveCertificate(string) error
 }
 
 type cryptoService interface {
@@ -378,10 +378,10 @@ func (n *Node) Start() {
 	n.Stop()
 }
 
-func (n *Node) SavePrivateKey() error {
-	return n.cm.SavePrivateKey()
+func (n *Node) SavePrivateKey(path string) error {
+	return n.cm.SavePrivateKey(path)
 }
 
-func (n *Node) SaveCertificate() error {
-	return n.cm.SaveCertificate()
+func (n *Node) SaveCertificate(path string) error {
+	return n.cm.SaveCertificate(path)
 }

--- a/core/node.go
+++ b/core/node.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -384,14 +384,14 @@ func (n *Node) Start() {
 /* Save private key for node crypto-unit to new file in argument directory-path.
  * - marius
  */
-func (n *Node) SavePrivateKey(p string) error {
-	if p == "" {
+func (n *Node) SavePrivateKey(path string) error {
+	if path == "" {
 		return errInvlKeyPath
 	}
 
-	p = path.Join(p, "key.pem")
+	path = filepath.Join(path, "key.pem")
 
-	f, err := os.Create(p)
+	f, err := os.Create(path)
 	if err != nil {
 		return err
 	}
@@ -417,14 +417,14 @@ func (n *Node) SavePrivateKey(p string) error {
 /* Save certificates for network-neighbours in new files inside argument path.
  * - marius
  */
-func (n *Node) SaveCertificates(p string) error {
-	if p == "" {
+func (n *Node) SaveCertificates(path string) error {
+	if path == "" {
 		return errInvlKeyPath
 	}
 
 	for _, cert := range n.cm.ContactList() {
 
-		certPath := path.Join(p, fmt.Sprintf("g-%s.pem", cert.SerialNumber))
+		certPath := filepath.Join(path, fmt.Sprintf("g-%s.pem", cert.SerialNumber))
 
 		f, err := os.Create(certPath)
 		if err != nil {

--- a/core/node.go
+++ b/core/node.go
@@ -94,8 +94,8 @@ type certManager interface {
 	ContactList() []*x509.Certificate
 	NumRings() uint32
 	Trusted() bool
-	SavePrivateKey(string) error
-	SaveCertificate(string) error
+	SavePrivateKey() error
+	SaveCertificate() error
 }
 
 type cryptoService interface {
@@ -378,10 +378,10 @@ func (n *Node) Start() {
 	n.Stop()
 }
 
-func (n *Node) SavePrivateKey(path string) error {
-	return n.cm.SavePrivateKey(path)
+func (n *Node) SavePrivateKey() error {
+	return n.cm.SavePrivateKey()
 }
 
-func (n *Node) SaveCertificate(path string) error {
-	return n.cm.SaveCertificate(path)
+func (n *Node) SaveCertificate() error {
+	return n.cm.SaveCertificate()
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jinzhu/configor v1.2.0
 	github.com/joonnna/workerpool v0.0.0-20180531065140-2c82629f6727
 	github.com/rs/cors v1.7.0
+	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.0
 	golang.org/x/net v0.0.0-20200528225125-3c3fba18258b

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -73,9 +73,11 @@ func ListenOnPort(port int) (net.Listener, error) {
 
 /* Change: Added port as specifiable argument. If passed argument is zero functionality will be as before.
  * Reason: net.Listen automatically chooses which port to listen to if Port field is zero.
+ *
+ * Change: Added hostname as argument that supports being an empty string.
  * - marius
  */
-func GetListener(portnum int) (net.Listener, error) {
+func GetListener(hostname string, portnum int) (net.Listener, error) {
 	var l net.Listener
 	var err error
 
@@ -86,6 +88,10 @@ func GetListener(portnum int) (net.Listener, error) {
 	addr, err := net.LookupHost(h)
 	if err != nil {
 		return nil, err
+	}
+
+	if hostname != "" {
+		addr[0] = hostname
 	}
 
 	for {
@@ -147,14 +153,20 @@ func LocalIP() (string, error) {
 
 /* Change: Added port as specifiable argument. If passed argument is zero functionality will be as before.
  * Reason: net.ListenUDP automatically chooses which port to listen to if Port field is zero.
+ *
+ * Change: Added hostname as argument that supports being an empty string.
  * - marius
  */
-func ListenUdp(portnum int) (*net.UDPConn, string, error) {
+func ListenUdp(hostname string, portnum int) (*net.UDPConn, string, error) {
 	h, _ := os.Hostname()
 
 	addr, err := net.LookupHost(h)
 	if err != nil {
 		return nil, "", err
+	}
+
+	if hostname != "" {
+		addr[0] = hostname
 	}
 
 	udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", addr[0], portnum))

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -31,7 +31,7 @@ func GetOpenPort() int {
 		}
 		attempts++
 		if attempts > 100 {
-			return 0
+			break
 		}
 	}
 
@@ -71,7 +71,11 @@ func ListenOnPort(port int) (net.Listener, error) {
 	return l, nil
 }
 
-func GetListener() (net.Listener, error) {
+/* Change: Added port as specifiable argument. If passed argument is zero functionality will be as before.
+ * Reason: net.Listen automatically chooses which port to listen to if Port field is zero.
+ * - marius
+ */
+func GetListener(portnum int) (net.Listener, error) {
 	var l net.Listener
 	var err error
 
@@ -85,7 +89,7 @@ func GetListener() (net.Listener, error) {
 	}
 
 	for {
-		l, err = net.Listen("tcp4", fmt.Sprintf("%s:", addr[0]))
+		l, err = net.Listen("tcp4", fmt.Sprintf("%s:%d", addr[0], portnum))
 		if err == nil {
 			return l, nil
 		} else {
@@ -94,7 +98,8 @@ func GetListener() (net.Listener, error) {
 		attempts++
 
 		if attempts > 100 {
-			return l, errFoundNoPort
+			// Stop and return error instead of returing in iteration. - marius
+			break
 		}
 	}
 
@@ -140,7 +145,11 @@ func LocalIP() (string, error) {
 	return addrs[0].String(), nil
 }
 
-func ListenUdp() (*net.UDPConn, string, error) {
+/* Change: Added port as specifiable argument. If passed argument is zero functionality will be as before.
+ * Reason: net.ListenUDP automatically chooses which port to listen to if Port field is zero.
+ * - marius
+ */
+func ListenUdp(portnum int) (*net.UDPConn, string, error) {
 	h, _ := os.Hostname()
 
 	addr, err := net.LookupHost(h)
@@ -148,7 +157,7 @@ func ListenUdp() (*net.UDPConn, string, error) {
 		return nil, "", err
 	}
 
-	udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:0", addr[0]))
+	udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", addr[0], portnum))
 	if err != nil {
 		return nil, "", err
 	}

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -83,19 +83,21 @@ func GetListener(hostname string, portnum int) (net.Listener, error) {
 
 	attempts := 0
 
-	h, _ := os.Hostname()
+	/*
+		h, _ := os.Hostname()
 
-	addr, err := net.LookupHost(h)
-	if err != nil {
-		return nil, err
-	}
+		addr, err := net.LookupHost(h)
+		if err != nil {
+			return nil, err
+		}
 
-	if hostname != "" {
-		addr[0] = hostname
-	}
+		if hostname != "" {
+			addr[0] = hostname
+		}
+	*/
 
 	for {
-		l, err = net.Listen("tcp4", fmt.Sprintf("%s:%d", addr[0], portnum))
+		l, err = net.Listen("tcp4", fmt.Sprintf(":%d", portnum))
 		if err == nil {
 			return l, nil
 		} else {
@@ -169,7 +171,7 @@ func ListenUdp(hostname string, portnum int) (*net.UDPConn, string, error) {
 		addr[0] = hostname
 	}
 
-	udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", addr[0], portnum))
+	udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", portnum))
 	if err != nil {
 		return nil, "", err
 	}
@@ -179,8 +181,7 @@ func ListenUdp(hostname string, portnum int) (*net.UDPConn, string, error) {
 		return nil, "", err
 	}
 
-	port := strings.Split(conn.LocalAddr().String(), ":")[1]
-	fullAddr := fmt.Sprintf("%s:%s", addr[0], port)
+	fullAddr := fmt.Sprintf("%s:%d", hostname, portnum)
 
 	return conn, fullAddr, nil
 }


### PR DESCRIPTION
Appended to Client: 
Specifiable host-name, or ip-address, and ports for TCP- and UDP-server. 
Saving of received certificates and private-key from CA to disk, and option for loading content and avoiding contact with CA. 
Contact CA to receive certification and store them for later use. 

Removed from CA:
Validation of ip-address from requesting client. 